### PR TITLE
Set `next-error-last-buffer' after running sbt command

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -173,6 +173,7 @@ subsequent call to this function may provide additional input."
         (sbt:clear (current-buffer))
       (ignore-errors (compilation-forget-errors)))
     (comint-send-string (current-buffer) (concat command "\n"))
+    (setq next-error-last-buffer (current-buffer))
     (setq sbt:previous-command command)))
 
 (defun sbt:get-previous-command ()


### PR DESCRIPTION
Hi,

I noticed that when I have a sbt buffer opened with compilation errors, using `next-error` (M-g M-n) does not jump to the sbt error but uses the previous compilation buffer, e.g. `grep` instead.  I am not sure if this is the correct way to do it but it at least fixes the behavior described above.

You can reproduce it like this:
- M-x grep, search for something with matches and goto some match
- Open scala file
- Run sbt and get errors
- M-g M-n will jump to the grep match, not the sbt error

Let me know what you think.

Best,
Markus
