### PR TITLE
Don't pass SBT empty string as an option

### DIFF
--- a/sbt-mode-vars.el
+++ b/sbt-mode-vars.el
@@ -14,7 +14,7 @@
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:program-options '("")
+(defcustom sbt:program-options '()
   "Options passed to sbt by the `sbt:run-sbt' command.
    See https://github.com/ensime/emacs-sbt-mode/issues/139 for older sbts"
   :type '(repeat string)


### PR DESCRIPTION
As of recent SBT (1.3 I think) sbt will immediately exit if it is passed
an empty command string. Hence using `sbt-mode` with the previous
default `sbt:program-options` would cause sbt to start and then
immediately exit.

This change specifies the empty program options as an empty list, which
doesn't cause sbt to exit, and makes `sbt-mode` useful again.