### PR TITLE
Disable supershell

### DIFF
--- a/sbt-mode-vars.el
+++ b/sbt-mode-vars.el
@@ -14,7 +14,7 @@
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:program-options '()
+(defcustom sbt:program-options '("-Dsbt.supershell=false")
   "Options passed to sbt by the `sbt:run-sbt' command.
    See https://github.com/ensime/emacs-sbt-mode/issues/139 for older sbts"
   :type '(repeat string)


### PR DESCRIPTION
The sbt supershell, introduced in sbt-1.3, doesn't play well with comint-mode.  Disabling it removes the unwanted control sequences and restores tab completion.