### PR TITLE
Add an interactive command for `testQuick`

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -118,6 +118,11 @@ sbt:default-command, if no other command has yet been run)."
   (interactive)
   (sbt-command "test"))
 
+(defun sbt-do-testquick ()
+  "Run all failing tests."
+  (interactive)
+  (sbt-command "testQuick"))
+
 (defun sbt-do-clean ()
   "Execute the sbt `clean' command for the project."
   (interactive)


### PR DESCRIPTION
Adds one more `sbt-do-*` function that targets the `testQuick` shell command.